### PR TITLE
[sdv] Added a synchronized block to avoid race condition while starting the game.

### DIFF
--- a/src/sdv/PlayTime/PlayManager.java
+++ b/src/sdv/PlayTime/PlayManager.java
@@ -79,6 +79,7 @@ public class PlayManager {
     }
 
     public Play createPlay(int player_id, int playID) throws IOException{
+      synchronized(this) {  // synchronized block added by Rupal on 3-30-2017
         Play play = this.playList.get(playID);
         if (play == null) {
 
@@ -112,6 +113,7 @@ public class PlayManager {
             
         }
         return play;
+      }
     }
 
     /**

--- a/src/sdv/net/Request/RequestNpcFishPosition.java
+++ b/src/sdv/net/Request/RequestNpcFishPosition.java
@@ -22,7 +22,7 @@ public class RequestNpcFishPosition extends GameRequest{
     @Override
     public void parse() throws IOException {
         numFish = Integer.parseInt(DataReader.readString(dataInput));
-        System.out.println("Num fish is " + numFish);
+        //System.out.println("Num fish is " + numFish);
         Prey fish;
         while(numFish > 0){
             fish = new Prey();
@@ -32,7 +32,7 @@ public class RequestNpcFishPosition extends GameRequest{
             fish.setY(Float.parseFloat(DataReader.readString(dataInput)));
             fish.setRotation(Float.parseFloat(DataReader.readString(dataInput)));
             fishMap.put(fish.getPrey_id(),fish);
-            System.out.println("Parsed. ");
+            //System.out.println("Parsed. ");
             numFish--;
         }
     }

--- a/src/sdv/net/Request/RequestPlayInit.java
+++ b/src/sdv/net/Request/RequestPlayInit.java
@@ -30,6 +30,7 @@ public class RequestPlayInit extends GameRequest {
 
     @Override
     public void doBusiness() throws Exception {
+
         int tester; //number of players in game test.
         Log.println("Trying to start Play: PlayerID[" +
                 player_id + "], RoomID[" + room_id + "]");
@@ -72,7 +73,7 @@ public class RequestPlayInit extends GameRequest {
             try{
             int opp_id= PlayManager.getInstance().getPlayByPlayerID(client.getPlayer().getPlayer_id())
                 .getOpponent(client.getPlayer()).getPlayer_id();
-            
+
             /* this is meant for adding a response for all players in a match.
             for(int p_id : play.getPlayers().keySet()) {
                 NetworkManager.addResponseForUser(p_id, response);
@@ -84,8 +85,6 @@ public class RequestPlayInit extends GameRequest {
             }
             Log.println("Play created with players: " + play.getPlayers().keySet().toString());
         }
-        
-        
         
     }
     


### PR DESCRIPTION
PlayInitRequest sent from both clients after they were paired caused both users to be put in separate games, thus waiting for another opponent to join. 
This did not happen when running both clients on the same machine as Unity would stall the execution of the 2nd client as it was in the background - forcing the requests to be sent one after the other. 

Added a synchronized block to prevent both clients from getting put into their own games due to a race condition. Removed some debug print statements. 